### PR TITLE
Ignore RESCOPED PR events.

### DIFF
--- a/src/main/java/com/pragbits/stash/components/PullRequestActivityListener.java
+++ b/src/main/java/com/pragbits/stash/components/PullRequestActivityListener.java
@@ -59,6 +59,11 @@ public class PullRequestActivityListener {
             String userName = event.getUser() != null ? event.getUser().getDisplayName() : "unknown user";
             String activity = event.getActivity().getAction().name();
 
+            // Ignore RESCOPED PR events
+            if (activity.equalsIgnoreCase("RESCOPED")) {
+                return;
+            }
+
             String url = navBuilder
                     .project(projectName)
                     .repo(repoName)


### PR DESCRIPTION
Hey @pragbits 
This is a PR to ignore RESCOPED PR events (seem to be part of internal process of Stash PR's / auto-merging.

Care to take a look?