### PR TITLE
Updates to message formatting for pull request events

### DIFF
--- a/src/main/java/com/pragbits/stash/SlackGlobalSettingsServlet.java
+++ b/src/main/java/com/pragbits/stash/SlackGlobalSettingsServlet.java
@@ -9,6 +9,7 @@ import com.atlassian.stash.nav.NavBuilder;
 import com.pragbits.stash.PluginMetadata;
 import com.atlassian.stash.repository.Repository;
 import com.atlassian.stash.repository.RepositoryService;
+import com.atlassian.stash.avatar.AvatarService;
 import com.atlassian.stash.user.Permission;
 import com.atlassian.stash.user.PermissionValidationService;
 import com.atlassian.webresource.api.assembler.PageBuilderService;

--- a/src/main/java/com/pragbits/stash/tools/SlackAttachment.java
+++ b/src/main/java/com/pragbits/stash/tools/SlackAttachment.java
@@ -32,6 +32,30 @@ public class SlackAttachment {
         return color;
     }
 
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public String getAuthorName() {
+        return author_name;
+    }
+
+    public void setAuthorName(String author_name) {
+        this.author_name = author_name;
+    }
+
+    public String getAuthorIcon() {
+        return author_icon;
+    }
+
+    public void setAuthorIcon(String author_icon) {
+        this.author_icon = author_icon;
+    }
+
     public void setColor(String color) {
         this.color = color;
     }
@@ -68,4 +92,7 @@ public class SlackAttachment {
     private String fallback;
     private String pretext;
     private String color;
+    private String text;
+    private String author_name;
+    private String author_icon;
 }

--- a/src/main/java/com/pragbits/stash/tools/SlackPayload.java
+++ b/src/main/java/com/pragbits/stash/tools/SlackPayload.java
@@ -35,6 +35,16 @@ public class SlackPayload {
 
     private boolean mrkdwn;
 
+    public boolean isLinkNames() {
+        return link_names;
+    }
+
+    public void setLinkNames(boolean link_names) {
+        this.link_names = link_names;
+    }
+
+    private boolean link_names;
+
     private List<SlackAttachment> attachments = new LinkedList<SlackAttachment>();
 
     public void addAttachment(SlackAttachment slackAttachment) {

--- a/src/main/resources/META-INF/spring/atlassian-plugin-context.xml
+++ b/src/main/resources/META-INF/spring/atlassian-plugin-context.xml
@@ -24,8 +24,9 @@
         <constructor-arg index="1" ref="slackSettingsService" />
         <constructor-arg index="2" ref="navBuilder" />
         <constructor-arg index="3" ref="slackNotifier" />
+        <constructor-arg index="4" ref="avatarService" />
     </bean>
-    
+
     <bean id="repositoryPushActivityListener"
           class="com.pragbits.stash.components.RepositoryPushActivityListener">
         <constructor-arg index="0" ref="slackGlobalSettingsService" />
@@ -36,4 +37,3 @@
     </bean>
 
 </beans>
-

--- a/src/main/resources/META-INF/spring/atlassian-plugins-component-imports.xml
+++ b/src/main/resources/META-INF/spring/atlassian-plugins-component-imports.xml
@@ -12,9 +12,9 @@
     <osgi:reference id="permissionValidationService" interface="com.atlassian.stash.user.PermissionValidationService"/>
     <osgi:reference id="pluginSettingsFactory" interface="com.atlassian.sal.api.pluginsettings.PluginSettingsFactory"/>
     <osgi:reference id="repositoryService" interface="com.atlassian.stash.repository.RepositoryService"/>
+    <osgi:reference id="avatarService" interface="com.atlassian.stash.avatar.AvatarService"/>
     <osgi:reference id="soyTemplateRenderer" interface="com.atlassian.soy.renderer.SoyTemplateRenderer"/>
     <osgi:reference id="navBuilder" interface="com.atlassian.stash.nav.NavBuilder"/>
     <osgi:reference id="commitService" interface="com.atlassian.stash.commit.CommitService"/>
 
 </beans>
-


### PR DESCRIPTION
This PR adds more details about pull request events, such as the source and destination repos/branches, as well as publishing the author name and avatar, to address #11.

![image](https://cloud.githubusercontent.com/assets/1014544/7825728/881d8a02-03de-11e5-80a3-bd40aea9e830.png)
