### PR TITLE
Push notification level

### DIFF
--- a/src/main/java/com/pragbits/stash/ColorCode.java
+++ b/src/main/java/com/pragbits/stash/ColorCode.java
@@ -1,0 +1,22 @@
+package com.pragbits.stash;
+
+public enum ColorCode {
+
+    BLUE("#2267c4"),
+    PALE_BLUE("#439fe0"),
+    GREEN("#2dc422"),
+    PURPLE("#9055fc"),
+    GRAY("#aabbcc"),
+    RED("#ff0024");
+
+    private String code;
+
+    ColorCode(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+}

--- a/src/main/java/com/pragbits/stash/DefaultSlackSettingsService.java
+++ b/src/main/java/com/pragbits/stash/DefaultSlackSettingsService.java
@@ -2,8 +2,6 @@ package com.pragbits.stash;
 
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
-import com.pragbits.stash.SlackSettings;
-import com.pragbits.stash.SlackSettingsService;
 import com.atlassian.stash.repository.Repository;
 import com.atlassian.stash.user.Permission;
 import com.atlassian.stash.user.PermissionValidationService;
@@ -32,6 +30,7 @@ public class DefaultSlackSettingsService implements SlackSettingsService {
             true,   // merged
             true,   // commented
             false,  // push enabled
+            PushNotificationLevel.VERBOSE,
             "",     // channel name override
             "");    // webhook override
 
@@ -45,6 +44,7 @@ public class DefaultSlackSettingsService implements SlackSettingsService {
     static final String KEY_SLACK_MERGED_NOTIFICATION = "slackNotificationsMergedEnabled";
     static final String KEY_SLACK_COMMENTED_NOTIFICATION = "slackNotificationsCommentedEnabled";
     static final String KEY_SLACK_NOTIFICATION_PUSH = "slackNotificationsEnabledForPush";
+    static final String KEY_SLACK_PUSH_NOTIFICATION_LEVEL = "slackPushNotificationLevel";
     static final String KEY_SLACK_CHANNEL_NAME = "slackChannelName";
     static final String KEY_SLACK_WEBHOOK_URL = "slackWebHookUrl";
 
@@ -105,6 +105,7 @@ public class DefaultSlackSettingsService implements SlackSettingsService {
                 .put(KEY_SLACK_MERGED_NOTIFICATION, Boolean.toString(settings.isSlackNotificationsMergedEnabled()))
                 .put(KEY_SLACK_COMMENTED_NOTIFICATION, Boolean.toString(settings.isSlackNotificationsCommentedEnabled()))
                 .put(KEY_SLACK_NOTIFICATION_PUSH, Boolean.toString(settings.isSlackNotificationsEnabledForPush()))
+                .put(KEY_SLACK_PUSH_NOTIFICATION_LEVEL, settings.getPushNotificationLevel().toString())
                 .put(KEY_SLACK_CHANNEL_NAME, settings.getSlackChannelName().isEmpty() ? " " : settings.getSlackChannelName())
                 .put(KEY_SLACK_WEBHOOK_URL, settings.getSlackWebHookUrl().isEmpty() ? " " : settings.getSlackWebHookUrl())
                 .build();
@@ -126,6 +127,7 @@ public class DefaultSlackSettingsService implements SlackSettingsService {
                 Boolean.parseBoolean(settings.get(KEY_SLACK_MERGED_NOTIFICATION)),
                 Boolean.parseBoolean(settings.get(KEY_SLACK_COMMENTED_NOTIFICATION)),
                 Boolean.parseBoolean(settings.get(KEY_SLACK_NOTIFICATION_PUSH)),
+                settings.containsKey(KEY_SLACK_PUSH_NOTIFICATION_LEVEL) ? PushNotificationLevel.valueOf(settings.get(KEY_SLACK_PUSH_NOTIFICATION_LEVEL)) : PushNotificationLevel.VERBOSE,
                 settings.get(KEY_SLACK_CHANNEL_NAME).toString().equals(" ") ? "" : settings.get(KEY_SLACK_CHANNEL_NAME).toString(),
                 settings.get(KEY_SLACK_WEBHOOK_URL).toString().equals(" ") ? "" : settings.get(KEY_SLACK_WEBHOOK_URL).toString()
         );

--- a/src/main/java/com/pragbits/stash/ImmutableSlackSettings.java
+++ b/src/main/java/com/pragbits/stash/ImmutableSlackSettings.java
@@ -12,6 +12,7 @@ public class ImmutableSlackSettings implements SlackSettings {
     private final boolean slackNotificationsMergedEnabled;
     private final boolean slackNotificationsCommentedEnabled;
     private final boolean slackNotificationsEnabledForPush;
+    private final PushNotificationLevel pushNotificationLevel;
     private final String slackChannelName;
     private final String slackWebHookUrl;
 
@@ -25,6 +26,7 @@ public class ImmutableSlackSettings implements SlackSettings {
                                   boolean slackNotificationsMergedEnabled,
                                   boolean slackNotificationsCommentedEnabled,
                                   boolean slackNotificationsEnabledForPush,
+                                  PushNotificationLevel pushNotificationLevel,
                                   String slackChannelName,
                                   String slackWebHookUrl) {
         this.slackNotificationsEnabled = slackNotificationsEnabled;
@@ -37,6 +39,7 @@ public class ImmutableSlackSettings implements SlackSettings {
         this.slackNotificationsMergedEnabled = slackNotificationsMergedEnabled;
         this.slackNotificationsCommentedEnabled = slackNotificationsCommentedEnabled;
         this.slackNotificationsEnabledForPush = slackNotificationsEnabledForPush;
+        this.pushNotificationLevel = pushNotificationLevel;
         this.slackChannelName = slackChannelName;
         this.slackWebHookUrl = slackWebHookUrl;
     }
@@ -81,6 +84,10 @@ public class ImmutableSlackSettings implements SlackSettings {
         return slackNotificationsEnabledForPush;
     }
 
+    public PushNotificationLevel getPushNotificationLevel() {
+        return pushNotificationLevel;
+    }
+
     public String getSlackChannelName() {
         return slackChannelName;
     }
@@ -101,6 +108,7 @@ public class ImmutableSlackSettings implements SlackSettings {
                 ", slackNotificationsMergedEnabled=" + slackNotificationsMergedEnabled +
                 ", slackNotificationsCommentedEnabled=" + slackNotificationsCommentedEnabled +
                 ", slackNotificationsEnabledForPush=" + slackNotificationsEnabledForPush +
+                ", pushNotificationLevel=" + pushNotificationLevel +
                 ", slackChannelName=" + slackChannelName +
                 ", slackWebHookUrl=" + slackWebHookUrl + "}";
     }

--- a/src/main/java/com/pragbits/stash/PushNotificationLevel.java
+++ b/src/main/java/com/pragbits/stash/PushNotificationLevel.java
@@ -1,0 +1,7 @@
+package com.pragbits.stash;
+
+public enum PushNotificationLevel {
+    MINIMAL,
+    COMPACT,
+    VERBOSE
+}

--- a/src/main/java/com/pragbits/stash/PushNotificationLevel.java
+++ b/src/main/java/com/pragbits/stash/PushNotificationLevel.java
@@ -1,7 +1,26 @@
 package com.pragbits.stash;
 
-public enum PushNotificationLevel {
-    MINIMAL,
-    COMPACT,
-    VERBOSE
+import com.pragbits.stash.soy.SelectFieldOption;
+
+public enum PushNotificationLevel implements SelectFieldOption {
+    MINIMAL("Minimal"),
+    COMPACT("Compact"),
+    VERBOSE("Verbose");
+
+    private final String text;
+
+    PushNotificationLevel(String text) {
+        this.text = text;
+    }
+
+    @Override
+    public String text() {
+        return text;
+    }
+
+    @Override
+    public String value() {
+        return name();
+    }
+
 }

--- a/src/main/java/com/pragbits/stash/SlackSettings.java
+++ b/src/main/java/com/pragbits/stash/SlackSettings.java
@@ -12,6 +12,7 @@ public interface SlackSettings {
     boolean isSlackNotificationsMergedEnabled();
     boolean isSlackNotificationsCommentedEnabled();
     boolean isSlackNotificationsEnabledForPush();
+    PushNotificationLevel getPushNotificationLevel();
     String getSlackChannelName();
     String getSlackWebHookUrl();
 

--- a/src/main/java/com/pragbits/stash/SlackSettingsServlet.java
+++ b/src/main/java/com/pragbits/stash/SlackSettingsServlet.java
@@ -3,10 +3,6 @@ package com.pragbits.stash;
 import com.atlassian.soy.renderer.SoyException;
 import com.atlassian.soy.renderer.SoyTemplateRenderer;
 import com.atlassian.stash.exception.AuthorisationException;
-import com.atlassian.stash.nav.NavBuilder;
-import com.pragbits.stash.SlackSettings;
-import com.pragbits.stash.SlackSettingsService;
-import com.pragbits.stash.PluginMetadata;
 import com.atlassian.stash.repository.Repository;
 import com.atlassian.stash.repository.RepositoryService;
 import com.atlassian.stash.user.Permission;
@@ -108,6 +104,11 @@ public class SlackSettingsServlet extends HttpServlet {
             enabledPush = true;
         }
 
+        PushNotificationLevel pushNotificationLevel = PushNotificationLevel.VERBOSE;
+        if (null != req.getParameter("slackPushNotificationLevel")) {
+            pushNotificationLevel = PushNotificationLevel.valueOf(req.getParameter("slackPushNotificationLevel"));
+        }
+
         String channel = req.getParameter("slackChannelName");
         String webHookUrl = req.getParameter("slackWebHookUrl");
         slackSettingsService.setSlackSettings(
@@ -123,6 +124,7 @@ public class SlackSettingsServlet extends HttpServlet {
                         mergedEnabled,
                         commentedEnabled,
                         enabledPush,
+                        pushNotificationLevel,
                         channel,
                         webHookUrl));
 

--- a/src/main/java/com/pragbits/stash/SlackSettingsServlet.java
+++ b/src/main/java/com/pragbits/stash/SlackSettingsServlet.java
@@ -11,6 +11,8 @@ import com.atlassian.webresource.api.assembler.PageBuilderService;
 import com.atlassian.stash.i18n.I18nService;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.pragbits.stash.soy.SelectFieldOptions;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -165,6 +167,7 @@ public class SlackSettingsServlet extends HttpServlet {
                 ImmutableMap.<String, Object>builder()
                         .put("repository", repository)
                         .put("slackSettings", slackSettings)
+                        .put("pushNotificationLevels", new SelectFieldOptions(PushNotificationLevel.values()).toSoyStructure())
                         .build()
         );
     }

--- a/src/main/java/com/pragbits/stash/components/PullRequestActivityListener.java
+++ b/src/main/java/com/pragbits/stash/components/PullRequestActivityListener.java
@@ -5,15 +5,12 @@ import com.atlassian.stash.event.pull.PullRequestActivityEvent;
 import com.atlassian.stash.event.pull.PullRequestCommentActivityEvent;
 import com.atlassian.stash.event.pull.PullRequestRescopeActivityEvent;
 import com.atlassian.stash.nav.NavBuilder;
-import com.atlassian.stash.pull.PullRequestActivity;
 import com.atlassian.stash.pull.PullRequestParticipant;
-import com.atlassian.stash.pull.PullRequestRescopeActivity;
-import com.atlassian.stash.pull.PullRequestState;
 import com.atlassian.stash.repository.Repository;
 import com.atlassian.stash.avatar.AvatarService;
 import com.atlassian.stash.avatar.AvatarRequest;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.pragbits.stash.ColorCode;
 import com.pragbits.stash.SlackGlobalSettingsService;
 import com.pragbits.stash.SlackSettings;
 import com.pragbits.stash.SlackSettingsService;
@@ -21,7 +18,6 @@ import com.pragbits.stash.tools.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -132,7 +128,7 @@ public class PullRequestActivityListener {
 
             switch (event.getActivity().getAction()) {
                 case OPENED:
-                    attachment.setColor("#2267c4"); // blue
+                    attachment.setColor(ColorCode.BLUE.getCode());
                     attachment.setFallback(String.format("%s opened pull request \"%s\". <%s|(open)>",
                                                             userName,
                                                             event.getPullRequest().getTitle(),
@@ -147,7 +143,7 @@ public class PullRequestActivityListener {
                     break;
 
                 case REOPENED:
-                    attachment.setColor("#2267c4"); // blue
+                    attachment.setColor(ColorCode.BLUE.getCode());
                     attachment.setFallback(String.format("%s reopened pull request \"%s\". <%s|(open)>",
                                                             userName,
                                                             event.getPullRequest().getTitle(),
@@ -162,7 +158,7 @@ public class PullRequestActivityListener {
                     break;
 
                 case UPDATED:
-                    attachment.setColor("#9055fc"); // purple
+                    attachment.setColor(ColorCode.PURPLE.getCode());
                     attachment.setFallback(String.format("%s updated pull request \"%s\". <%s|(open)>",
                                                             userName,
                                                             event.getPullRequest().getTitle(),
@@ -177,7 +173,7 @@ public class PullRequestActivityListener {
                     break;
 
                 case APPROVED:
-                    attachment.setColor("#2dc422"); // green
+                    attachment.setColor(ColorCode.GREEN.getCode());
                     attachment.setFallback(String.format("%s approved pull request \"%s\". <%s|(open)>",
                                                             userName,
                                                             event.getPullRequest().getTitle(),
@@ -189,7 +185,7 @@ public class PullRequestActivityListener {
                     break;
 
                 case UNAPPROVED:
-                    attachment.setColor("#ff0024"); // red
+                    attachment.setColor(ColorCode.RED.getCode());
                     attachment.setFallback(String.format("%s unapproved pull request \"%s\". <%s|(open)>",
                                                             userName,
                                                             event.getPullRequest().getTitle(),
@@ -201,7 +197,7 @@ public class PullRequestActivityListener {
                     break;
 
                 case DECLINED:
-                    attachment.setColor("#ff0024"); // red
+                    attachment.setColor(ColorCode.RED.getCode());
                     attachment.setFallback(String.format("%s declined pull request \"%s\". <%s|(open)>",
                                                             userName,
                                                             event.getPullRequest().getTitle(),
@@ -213,7 +209,7 @@ public class PullRequestActivityListener {
                     break;
 
                 case MERGED:
-                    attachment.setColor("#2dc422"); // green
+                    attachment.setColor(ColorCode.GREEN.getCode());
                     attachment.setFallback(String.format("%s merged pull request \"%s\". <%s|(open)>",
                                                             userName,
                                                             event.getPullRequest().getTitle(),
@@ -225,7 +221,7 @@ public class PullRequestActivityListener {
                     break;
 
                 case RESCOPED:
-                    attachment.setColor("#9055fc"); // purple
+                    attachment.setColor(ColorCode.PURPLE.getCode());
                     attachment.setFallback(String.format("%s rescoped on pull request \"%s\". <%s|(open)>",
                                                             userName,
                                                             event.getPullRequest().getTitle(),
@@ -237,7 +233,7 @@ public class PullRequestActivityListener {
                     break;
 
                 case COMMENTED:
-                    attachment.setColor("#439fe0"); // pale blue
+                    attachment.setColor(ColorCode.PALE_BLUE.getCode());
                     attachment.setFallback(String.format("%s commented on pull request \"%s\". <%s|(open)>",
                                                             userName,
                                                             event.getPullRequest().getTitle(),

--- a/src/main/java/com/pragbits/stash/components/RepositoryPushActivityListener.java
+++ b/src/main/java/com/pragbits/stash/components/RepositoryPushActivityListener.java
@@ -14,6 +14,7 @@ import com.atlassian.stash.util.PageRequest;
 import com.atlassian.stash.util.PageUtils;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
+import com.pragbits.stash.ColorCode;
 import com.pragbits.stash.SlackGlobalSettingsService;
 import com.pragbits.stash.SlackSettings;
 import com.pragbits.stash.SlackSettingsService;
@@ -144,7 +145,7 @@ public class RepositoryPushActivityListener {
 
     private void compactCommitLog(RepositoryPushEvent event, RefChange refChange, SlackPayload payload, String url, List<Changeset> myChanges) {
         SlackAttachment commits = new SlackAttachment();
-        commits.setColor("#aabbcc");
+        commits.setColor(ColorCode.GRAY.getCode());
         commits.setTitle(String.format("[%s:%s]", event.getRepository().getName(), refChange.getRefId()));
         StringBuilder attachmentFallback = new StringBuilder();
         for (Changeset ch : myChanges) {
@@ -168,7 +169,7 @@ public class RepositoryPushActivityListener {
         for (Changeset ch : myChanges) {
             SlackAttachment attachment = new SlackAttachment();
             attachment.setFallback(text);
-            attachment.setColor("#aabbcc");
+            attachment.setColor(ColorCode.GRAY.getCode());
             SlackAttachmentField field = new SlackAttachmentField();
 
             attachment.setTitle(String.format("[%s:%s] - %s", event.getRepository().getName(), refChange.getRefId(), ch.getId()));

--- a/src/main/java/com/pragbits/stash/soy/SelectFieldOption.java
+++ b/src/main/java/com/pragbits/stash/soy/SelectFieldOption.java
@@ -1,0 +1,8 @@
+package com.pragbits.stash.soy;
+
+public interface SelectFieldOption {
+
+    String text();
+    String value();
+
+}

--- a/src/main/java/com/pragbits/stash/soy/SelectFieldOptions.java
+++ b/src/main/java/com/pragbits/stash/soy/SelectFieldOptions.java
@@ -1,0 +1,27 @@
+package com.pragbits.stash.soy;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.Map;
+
+public class SelectFieldOptions {
+
+    private final SelectFieldOption[] options;
+
+    public SelectFieldOptions(SelectFieldOption[] options) {
+        this.options = options;
+    }
+
+    public List<Map<String, String>> toSoyStructure() {
+        return Lists.transform(Lists.newArrayList(options), new Function<SelectFieldOption, Map<String, String>>() {
+            @Override
+            public Map<String, String> apply(SelectFieldOption level) {
+                return ImmutableMap.of("text", level.text(), "value", level.value());
+            }
+        });
+    }
+
+}

--- a/src/main/resources/static/slackSettings.soy
+++ b/src/main/resources/static/slackSettings.soy
@@ -90,6 +90,16 @@
                     {param checked: $slackSettings.slackNotificationsEnabledForPush /}
                     {param description: stash_i18n('stash.web.slack.settings.slack.push.enabled.description', 'If enabled, users will receive slack notifications about push activities') /}
                 {/call}
+                {call aui.form.selectField}
+                    {param id: 'slackPushNotificationLevel' /}
+                    {param labelContent: stash_i18n('stash.web.slack.settings.push.notification.level.label', 'Notification level') /}
+                    {param value: $slackSettings.pushNotificationLevel /}
+                    {param options: [
+                        [ 'text': 'Minimal', 'value': 'MINIMAL' ],
+                        [ 'text': 'Compact', 'value': 'COMPACT' ],
+                        [ 'text': 'Verbose', 'value': 'VERBOSE' ]
+                    ] /}
+                {/call}
 
                 <h4>Channel and hook overrides</h4>
                 {call widget.aui.form.text}

--- a/src/main/resources/static/slackSettings.soy
+++ b/src/main/resources/static/slackSettings.soy
@@ -3,6 +3,7 @@
 /**
  * @param repository
  * @param slackSettings
+ * @param pushNotificationLevels
  **/
 {template .viewSlackSettings}
 <html>
@@ -94,11 +95,7 @@
                     {param id: 'slackPushNotificationLevel' /}
                     {param labelContent: stash_i18n('stash.web.slack.settings.push.notification.level.label', 'Notification level') /}
                     {param value: $slackSettings.pushNotificationLevel /}
-                    {param options: [
-                        [ 'text': 'Minimal', 'value': 'MINIMAL' ],
-                        [ 'text': 'Compact', 'value': 'COMPACT' ],
-                        [ 'text': 'Verbose', 'value': 'VERBOSE' ]
-                    ] /}
+                    {param options: $pushNotificationLevels /}
                 {/call}
 
                 <h4>Channel and hook overrides</h4>


### PR DESCRIPTION
Settings to choose the amount of information that's ported to slack.
Minimal -> Shows only the first line that's default for all the messages.
Compact -> Minimal and a simple list of the commits (hash, first line of the commit message and user)
Verbose -> The original message.

The compact message is inspired by the github bot for slack.