### PR TITLE
Feature: comments urls (rebased)

### DIFF
--- a/src/main/java/com/pragbits/bitbucketserver/components/PullRequestActivityListener.java
+++ b/src/main/java/com/pragbits/bitbucketserver/components/PullRequestActivityListener.java
@@ -132,10 +132,6 @@ public class PullRequestActivityListener {
             attachment.setAuthorName(userName);
             attachment.setAuthorIcon(avatar);
 
-            String color = "";
-            String fallback = "";
-            String text = "";
-
             switch (event.getActivity().getAction()) {
                 case OPENED:
                     attachment.setColor(ColorCode.BLUE.getCode());

--- a/src/main/java/com/pragbits/bitbucketserver/components/PullRequestActivityListener.java
+++ b/src/main/java/com/pragbits/bitbucketserver/components/PullRequestActivityListener.java
@@ -1,6 +1,7 @@
 package com.pragbits.bitbucketserver.components;
 
 import com.atlassian.event.api.EventListener;
+import com.atlassian.bitbucket.comment.Comment;
 import com.atlassian.bitbucket.event.pull.PullRequestActivityEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestCommentActivityEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestRescopeActivityEvent;
@@ -116,11 +117,13 @@ public class PullRequestActivityListener {
             if (activity.equalsIgnoreCase("COMMENTED") && !resolvedSlackSettings.isSlackNotificationsCommentedEnabled()) {
                 return;
             }
-            
-            String url = navBuilder
+
+            NavBuilder.PullRequest pullRequestUrlBuilder = navBuilder
                     .project(projectName)
                     .repo(repoName)
-                    .pullRequest(pullRequestId)
+                    .pullRequest(pullRequestId);
+
+            String url = pullRequestUrlBuilder
                     .overview()
                     .buildAbsolute();
 
@@ -253,20 +256,25 @@ public class PullRequestActivityListener {
                     break;
 
                 case COMMENTED:
+                    Comment comment = ((PullRequestCommentActivityEvent) event).getActivity().getComment();
+                    String commentUrl = pullRequestUrlBuilder
+                            .comment(comment.getId())
+                            .buildAbsolute();
+
                     attachment.setColor(ColorCode.PALE_BLUE.getCode());
                     attachment.setFallback(String.format("%s commented on pull request \"%s\". <%s|(open)>",
                                                             userName,
                                                             event.getPullRequest().getTitle(),
-                                                            url));
+                                                            commentUrl));
                     if (resolvedLevel == NotificationLevel.MINIMAL) {
                         attachment.setText(String.format("commented on pull request <%s|#%d: %s>",
-                                url,
+                                commentUrl,
                                 event.getPullRequest().getId(),
                                 event.getPullRequest().getTitle()));
                     }
                     if (resolvedLevel == NotificationLevel.COMPACT || resolvedLevel == NotificationLevel.VERBOSE) {
                         attachment.setText(String.format("commented on pull request <%s|#%d: %s>\n%s",
-                                url,
+                                commentUrl,
                                 event.getPullRequest().getId(),
                                 event.getPullRequest().getTitle(),
                                 ((PullRequestCommentActivityEvent) event).getActivity().getComment().getText()));


### PR DESCRIPTION
The common use case when a notification comes for a comment is to navigate to that comment and not the pull request. This fixes the link so we can navigate directly to the comment.

This is a rebase on master of https://github.com/pragbits/stash2slack/pull/25