### PR TITLE
use system http proxy settings for calling Slack

### DIFF
--- a/src/main/java/com/pragbits/bitbucketserver/tools/SlackNotifier.java
+++ b/src/main/java/com/pragbits/bitbucketserver/tools/SlackNotifier.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 
 public class SlackNotifier {
 
-    private final CloseableHttpClient httpClient = HttpClients.createDefault();
+    private final CloseableHttpClient httpClient = HttpClients.createSystem();
     private static final Logger log = LoggerFactory.getLogger(SlackNotifier.class);
 
     public  SlackNotifier() {


### PR DESCRIPTION
The [other SSL-related properties](https://wiki.apache.org/HttpComponents/HttpClientConfiguration) it uses from the system would probably be useful to some people too.