### PR TITLE
Trim hook url (+ refactoring settings)

### DIFF
--- a/src/main/java/com/pragbits/bitbucketserver/DefaultGlobalSlackSettingsService.java
+++ b/src/main/java/com/pragbits/bitbucketserver/DefaultGlobalSlackSettingsService.java
@@ -5,6 +5,21 @@ import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 
 public class DefaultGlobalSlackSettingsService implements SlackGlobalSettingsService {
+    private static final String KEY_GLOBAL_SETTING_HOOK_URL = "stash2slack.globalsettings.hookurl";
+    private static final String KEY_GLOBAL_SETTING_CHANNEL_NAME = "stash2slack.globalsettings.channelname";
+    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_ENABLED = "stash2slack.globalsettings.slacknotificationsenabled";
+    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_OPENED_ENABLED = "stash2slack.globalsettings.slacknotificationsopenedenabled";
+    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_REOPENED_ENABLED = "stash2slack.globalsettings.slacknotificationsreopenedenabled";
+    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_UPDATED_ENABLED = "stash2slack.globalsettings.slacknotificationsupdatedenabled";
+    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_APPROVED_ENABLED = "stash2slack.globalsettings.slacknotificationsapprovedenabled";
+    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_UNAPPROVED_ENABLED = "stash2slack.globalsettings.slacknotificationsunapprovedenabled";
+    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_DECLINED_ENABLED = "stash2slack.globalsettings.slacknotificationsdeclinedenabled";
+    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_MERGED_ENABLED = "stash2slack.globalsettings.slacknotificationsmergedenabled";
+    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_COMMENTED_ENABLED = "stash2slack.globalsettings.slacknotificationscommentedenabled";
+    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_LEVEL = "stash2slack.globalsettings.slacknotificationslevel";
+    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_PR_LEVEL = "stash2slack.globalsettings.slacknotificationsprlevel";
+    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_PUSH_ENABLED = "stash2slack.globalsettings.slacknotificationspushenabled";
+    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_PERSONAL_ENABLED = "stash2slack.globalsettings.slacknotificationspersonalenabled";
 
     private final PluginSettings pluginSettings;
 
@@ -13,173 +28,175 @@ public class DefaultGlobalSlackSettingsService implements SlackGlobalSettingsSer
     }
 
     @Override
-    public String getWebHookUrl(String key) {
-        Object retval = pluginSettings.get(key);
-        if (null == retval) {
-            return "";
-        }
-
-        return retval.toString();
+    public String getWebHookUrl() {
+        return getString(KEY_GLOBAL_SETTING_HOOK_URL);
     }
 
     @Override
-    public void setWebHookUrl(String key, String value) {
-        pluginSettings.put(key, value);
+    public void setWebHookUrl(String value) {
+        pluginSettings.put(KEY_GLOBAL_SETTING_HOOK_URL, value);
     }
 
     @Override
-    public String getChannelName(String key) {
-        Object retval = pluginSettings.get(key);
-        if (null == retval) {
-            return "";
-        }
-
-        return retval.toString();
+    public String getChannelName() {
+        return getString(KEY_GLOBAL_SETTING_CHANNEL_NAME);
     }
 
     @Override
-    public void setChannelName(String key, String value) {
-        pluginSettings.put(key, value);
+    public void setChannelName(String value) {
+        pluginSettings.put(KEY_GLOBAL_SETTING_CHANNEL_NAME, value);
     }
 
     @Override
-    public boolean getSlackNotificationsEnabled(String key) {
-        return Boolean.parseBoolean((String) pluginSettings.get(key));
+    public boolean getSlackNotificationsEnabled() {
+        return getBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_ENABLED);
     }
 
     @Override
-    public void setSlackNotificationsEnabled(String key, String value) {
-        pluginSettings.put(key, value);
+    public void setSlackNotificationsEnabled(boolean value) {
+        setBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_ENABLED, value);
     }
 
     @Override
-    public boolean getSlackNotificationsOpenedEnabled(String key) {
-        return Boolean.parseBoolean((String)pluginSettings.get(key));
+    public boolean getSlackNotificationsOpenedEnabled() {
+        return getBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_OPENED_ENABLED);
     }
 
     @Override
-    public void setSlackNotificationsOpenedEnabled(String key, String value) {
-        pluginSettings.put(key, value);
+    public void setSlackNotificationsOpenedEnabled(boolean value) {
+        setBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_OPENED_ENABLED, value);
     }
 
     @Override
-    public boolean getSlackNotificationsReopenedEnabled(String key) {
-        return Boolean.parseBoolean((String)pluginSettings.get(key));
+    public boolean getSlackNotificationsReopenedEnabled() {
+        return getBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_REOPENED_ENABLED);
     }
 
     @Override
-    public void setSlackNotificationsReopenedEnabled(String key, String value) {
-        pluginSettings.put(key, value);
+    public void setSlackNotificationsReopenedEnabled(boolean value) {
+        setBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_REOPENED_ENABLED, value);
     }
 
     @Override
-    public boolean getSlackNotificationsUpdatedEnabled(String key) {
-        return Boolean.parseBoolean((String)pluginSettings.get(key));
+    public boolean getSlackNotificationsUpdatedEnabled() {
+        return getBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_UPDATED_ENABLED);
     }
 
     @Override
-    public void setSlackNotificationsUpdatedEnabled(String key, String value) {
-        pluginSettings.put(key, value);
+    public void setSlackNotificationsUpdatedEnabled(boolean value) {
+        setBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_UPDATED_ENABLED, value);
     }
 
     @Override
-    public boolean getSlackNotificationsApprovedEnabled(String key) {
-        return Boolean.parseBoolean((String)pluginSettings.get(key));
+    public boolean getSlackNotificationsApprovedEnabled() {
+        return getBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_APPROVED_ENABLED);
     }
 
     @Override
-    public void setSlackNotificationsApprovedEnabled(String key, String value) {
-        pluginSettings.put(key, value);
+    public void setSlackNotificationsApprovedEnabled(boolean value) {
+        setBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_APPROVED_ENABLED, value);
     }
 
     @Override
-    public boolean getSlackNotificationsUnapprovedEnabled(String key) {
-        return Boolean.parseBoolean((String)pluginSettings.get(key));
+    public boolean getSlackNotificationsUnapprovedEnabled() {
+        return getBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_UNAPPROVED_ENABLED);
     }
 
     @Override
-    public void setSlackNotificationsUnapprovedEnabled(String key, String value) {
-        pluginSettings.put(key, value);
+    public void setSlackNotificationsUnapprovedEnabled(boolean value) {
+        setBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_UNAPPROVED_ENABLED, value);
     }
 
     @Override
-    public boolean getSlackNotificationsDeclinedEnabled(String key) {
-        return Boolean.parseBoolean((String)pluginSettings.get(key));
+    public boolean getSlackNotificationsDeclinedEnabled() {
+        return getBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_DECLINED_ENABLED);
     }
 
     @Override
-    public void setSlackNotificationsDeclinedEnabled(String key, String value) {
-        pluginSettings.put(key, value);
+    public void setSlackNotificationsDeclinedEnabled(boolean value) {
+        setBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_DECLINED_ENABLED, value);
     }
 
     @Override
-    public boolean getSlackNotificationsMergedEnabled(String key) {
-        return Boolean.parseBoolean((String)pluginSettings.get(key));
+    public boolean getSlackNotificationsMergedEnabled() {
+        return getBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_MERGED_ENABLED);
     }
 
     @Override
-    public void setSlackNotificationsMergedEnabled(String key, String value) {
-        pluginSettings.put(key, value);
+    public void setSlackNotificationsMergedEnabled(boolean value) {
+        setBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_MERGED_ENABLED, value);
     }
 
     @Override
-    public boolean getSlackNotificationsCommentedEnabled(String key) {
-        return Boolean.parseBoolean((String)pluginSettings.get(key));
+    public boolean getSlackNotificationsCommentedEnabled() {
+        return getBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_COMMENTED_ENABLED);
     }
 
     @Override
-    public void setSlackNotificationsCommentedEnabled(String key, String value) {
-        pluginSettings.put(key, value);
+    public void setSlackNotificationsCommentedEnabled(boolean value) {
+        setBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_COMMENTED_ENABLED, value);
     }
 
     @Override
-    public boolean getSlackNotificationsEnabledForPush(String key) {
-        return Boolean.parseBoolean((String)pluginSettings.get(key));
+    public boolean getSlackNotificationsEnabledForPush() {
+        return getBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_PUSH_ENABLED);
     }
 
     @Override
-    public void setSlackNotificationsEnabledForPush(String key, String value) {
-        pluginSettings.put(key, value);
+    public void setSlackNotificationsEnabledForPush(boolean value) {
+        setBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_PUSH_ENABLED, value);
     }
 
     @Override
-    public boolean getSlackNotificationsEnabledForPersonal(String key) {
-        return Boolean.parseBoolean((String)pluginSettings.get(key));
+    public boolean getSlackNotificationsEnabledForPersonal() {
+        return getBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_PERSONAL_ENABLED);
     }
 
     @Override
-    public void setSlackNotificationsEnabledForPersonal(String key, String value) {
-        pluginSettings.put(key, value);
+    public void setSlackNotificationsEnabledForPersonal(boolean value) {
+        setBoolean(KEY_GLOBAL_SETTING_NOTIFICATIONS_PERSONAL_ENABLED, value);
     }
 
     @Override
-    public NotificationLevel getNotificationLevel(String key) {
-        Object retval = pluginSettings.get(key);
-        if (null == retval) {
+    public NotificationLevel getNotificationLevel() {
+        String value = getString(KEY_GLOBAL_SETTING_NOTIFICATIONS_LEVEL);
+        if (value.isEmpty()) {
             return NotificationLevel.VERBOSE;
         } else {
-            return NotificationLevel.valueOf((String)pluginSettings.get(key));
+            return NotificationLevel.valueOf(value);
         }
     }
 
     @Override
-    public void setNotificationLevel(String key, String value) {
-        pluginSettings.put(key, value);
+    public void setNotificationLevel(String value) {
+        pluginSettings.put(KEY_GLOBAL_SETTING_NOTIFICATIONS_LEVEL, value);
     }
 
     @Override
-    public NotificationLevel getNotificationPrLevel(String key) {
-        Object retval = pluginSettings.get(key);
-        if (null == retval) {
+    public NotificationLevel getNotificationPrLevel() {
+        String value = getString(KEY_GLOBAL_SETTING_NOTIFICATIONS_PR_LEVEL);
+        if (value.isEmpty()) {
             return NotificationLevel.VERBOSE;
         } else {
-            return NotificationLevel.valueOf((String)pluginSettings.get(key));
+            return NotificationLevel.valueOf(value);
         }
     }
 
     @Override
-    public void setNotificationPrLevel(String key, String value) {
-        pluginSettings.put(key, value);
+    public void setNotificationPrLevel(String value) {
+        pluginSettings.put(KEY_GLOBAL_SETTING_NOTIFICATIONS_PR_LEVEL, value);
     }
 
+    private String getString(String key) {
+        Object value = pluginSettings.get(key);
+        return null == value ? "" : value.toString();
+    }
+
+    private boolean getBoolean(String key) {
+        return Boolean.parseBoolean((String)pluginSettings.get(key));
+    }
+
+    private void setBoolean(String key, Boolean value) {
+        pluginSettings.put(key, value.toString());
+    }
 }

--- a/src/main/java/com/pragbits/bitbucketserver/SlackGlobalSettingsService.java
+++ b/src/main/java/com/pragbits/bitbucketserver/SlackGlobalSettingsService.java
@@ -3,52 +3,50 @@ package com.pragbits.bitbucketserver;
 public interface SlackGlobalSettingsService {
 
     // hook and channel name
-    String getWebHookUrl(String key);
-    void setWebHookUrl(String key, String value);
+    String getWebHookUrl();
+    void setWebHookUrl(String value);
 
-    String getChannelName(String key);
-    void setChannelName(String key, String value);
+    String getChannelName();
+    void setChannelName(String value);
 
     // pull requests are enabled and pr events
-    boolean getSlackNotificationsEnabled(String key);
-    void setSlackNotificationsEnabled(String key, String value);
+    boolean getSlackNotificationsEnabled();
+    void setSlackNotificationsEnabled(boolean value);
 
-    boolean getSlackNotificationsOpenedEnabled(String key);
-    void setSlackNotificationsOpenedEnabled(String key, String value);
+    boolean getSlackNotificationsOpenedEnabled();
+    void setSlackNotificationsOpenedEnabled(boolean value);
 
-    boolean getSlackNotificationsReopenedEnabled(String key);
-    void setSlackNotificationsReopenedEnabled(String key, String value);
+    boolean getSlackNotificationsReopenedEnabled();
+    void setSlackNotificationsReopenedEnabled(boolean value);
 
-    boolean getSlackNotificationsUpdatedEnabled(String key);
-    void setSlackNotificationsUpdatedEnabled(String key, String value);
+    boolean getSlackNotificationsUpdatedEnabled();
+    void setSlackNotificationsUpdatedEnabled(boolean value);
 
-    boolean getSlackNotificationsApprovedEnabled(String key);
-    void setSlackNotificationsApprovedEnabled(String key, String value);
+    boolean getSlackNotificationsApprovedEnabled();
+    void setSlackNotificationsApprovedEnabled(boolean value);
 
-    boolean getSlackNotificationsUnapprovedEnabled(String key);
-    void setSlackNotificationsUnapprovedEnabled(String key, String value);
+    boolean getSlackNotificationsUnapprovedEnabled();
+    void setSlackNotificationsUnapprovedEnabled(boolean value);
 
-    boolean getSlackNotificationsDeclinedEnabled(String key);
-    void setSlackNotificationsDeclinedEnabled(String key, String value);
+    boolean getSlackNotificationsDeclinedEnabled();
+    void setSlackNotificationsDeclinedEnabled(boolean value);
 
-    boolean getSlackNotificationsMergedEnabled(String key);
-    void setSlackNotificationsMergedEnabled(String key, String value);
+    boolean getSlackNotificationsMergedEnabled();
+    void setSlackNotificationsMergedEnabled(boolean value);
 
-    boolean getSlackNotificationsCommentedEnabled(String key);
-    void setSlackNotificationsCommentedEnabled(String key, String value);
+    boolean getSlackNotificationsCommentedEnabled();
+    void setSlackNotificationsCommentedEnabled(boolean value);
 
     // push notifications are enabled and push options
-    boolean getSlackNotificationsEnabledForPush(String key);
-    void setSlackNotificationsEnabledForPush(String key, String value);
+    boolean getSlackNotificationsEnabledForPush();
+    void setSlackNotificationsEnabledForPush(boolean value);
 
-    NotificationLevel getNotificationLevel(String key);
-    void setNotificationLevel(String key, String value);
+    NotificationLevel getNotificationLevel();
+    void setNotificationLevel(String value);
 
-    NotificationLevel getNotificationPrLevel(String key);
-    void setNotificationPrLevel(String key, String value);
+    NotificationLevel getNotificationPrLevel();
+    void setNotificationPrLevel(String value);
 
-    boolean getSlackNotificationsEnabledForPersonal(String key);
-    void setSlackNotificationsEnabledForPersonal(String key, String value);
-
-
+    boolean getSlackNotificationsEnabledForPersonal();
+    void setSlackNotificationsEnabledForPersonal(boolean value);
 }

--- a/src/main/java/com/pragbits/bitbucketserver/SlackGlobalSettingsServlet.java
+++ b/src/main/java/com/pragbits/bitbucketserver/SlackGlobalSettingsServlet.java
@@ -18,22 +18,6 @@ import java.io.IOException;
 import java.util.Map;
 
 public class SlackGlobalSettingsServlet extends HttpServlet {
-    static final String KEY_GLOBAL_SETTING_HOOK_URL = "stash2slack.globalsettings.hookurl";
-    static final String KEY_GLOBAL_SETTING_CHANNEL_NAME = "stash2slack.globalsettings.channelname";
-    static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_ENABLED = "stash2slack.globalsettings.slacknotificationsenabled";
-    static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_OPENED_ENABLED = "stash2slack.globalsettings.slacknotificationsopenedenabled";
-    static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_REOPENED_ENABLED = "stash2slack.globalsettings.slacknotificationsreopenedenabled";
-    static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_UPDATED_ENABLED = "stash2slack.globalsettings.slacknotificationsupdatedenabled";
-    static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_APPROVED_ENABLED = "stash2slack.globalsettings.slacknotificationsapprovedenabled";
-    static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_UNAPPROVED_ENABLED = "stash2slack.globalsettings.slacknotificationsunapprovedenabled";
-    static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_DECLINED_ENABLED = "stash2slack.globalsettings.slacknotificationsdeclinedenabled";
-    static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_MERGED_ENABLED = "stash2slack.globalsettings.slacknotificationsmergedenabled";
-    static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_COMMENTED_ENABLED = "stash2slack.globalsettings.slacknotificationscommentedenabled";
-    static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_LEVEL = "stash2slack.globalsettings.slacknotificationslevel";
-    static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_PR_LEVEL = "stash2slack.globalsettings.slacknotificationsprlevel";
-    static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_PUSH_ENABLED = "stash2slack.globalsettings.slacknotificationspushenabled";
-    static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_PERSONAL_ENABLED = "stash2slack.globalsettings.slacknotificationspersonalenabled";
-
     private final PageBuilderService pageBuilderService;
     private final SlackGlobalSettingsService slackGlobalSettingsService;
     private final SoyTemplateRenderer soyTemplateRenderer;
@@ -65,56 +49,33 @@ public class SlackGlobalSettingsServlet extends HttpServlet {
             return;
         }
 
-        final String globalWebHookUrl = req.getParameter("slackGlobalWebHookUrl").trim();
-        slackGlobalSettingsService.setWebHookUrl(KEY_GLOBAL_SETTING_HOOK_URL, globalWebHookUrl);
+        slackGlobalSettingsService.setWebHookUrl(req.getParameter("slackGlobalWebHookUrl").trim());
+        slackGlobalSettingsService.setChannelName(req.getParameter("slackChannelName"));
 
-        String slackChannelName = req.getParameter("slackChannelName");
-        slackGlobalSettingsService.setChannelName(KEY_GLOBAL_SETTING_CHANNEL_NAME, slackChannelName);
-
-        Boolean slackNotificationsEnabled = "on".equals(req.getParameter("slackNotificationsEnabled"));
-        slackGlobalSettingsService.setSlackNotificationsEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_ENABLED, slackNotificationsEnabled.toString());
-
-        Boolean slackNotificationsOpenedEnabled = "on".equals(req.getParameter("slackNotificationsOpenedEnabled"));
-        slackGlobalSettingsService.setSlackNotificationsOpenedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_OPENED_ENABLED, slackNotificationsOpenedEnabled.toString());
-
-        Boolean slackNotificationsReopenedEnabled = "on".equals(req.getParameter("slackNotificationsReopenedEnabled"));
-        slackGlobalSettingsService.setSlackNotificationsReopenedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_REOPENED_ENABLED, slackNotificationsReopenedEnabled.toString());
-
-        Boolean slackNotificationsUpdatedEnabled = "on".equals(req.getParameter("slackNotificationsUpdatedEnabled"));
-        slackGlobalSettingsService.setSlackNotificationsUpdatedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_UPDATED_ENABLED, slackNotificationsUpdatedEnabled.toString());
-
-        Boolean slackNotificationsApprovedEnabled = "on".equals(req.getParameter("slackNotificationsApprovedEnabled"));
-        slackGlobalSettingsService.setSlackNotificationsApprovedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_APPROVED_ENABLED, slackNotificationsApprovedEnabled.toString());
-
-        Boolean slackNotificationsUnapprovedEnabled = "on".equals(req.getParameter("slackNotificationsUnapprovedEnabled"));
-        slackGlobalSettingsService.setSlackNotificationsUnapprovedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_UNAPPROVED_ENABLED, slackNotificationsUnapprovedEnabled.toString());
-
-        Boolean slackNotificationsDeclinedEnabled = "on".equals(req.getParameter("slackNotificationsDeclinedEnabled"));
-        slackGlobalSettingsService.setSlackNotificationsDeclinedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_DECLINED_ENABLED, slackNotificationsDeclinedEnabled.toString());
-
-        Boolean slackNotificationsMergedEnabled = "on".equals(req.getParameter("slackNotificationsMergedEnabled"));
-        slackGlobalSettingsService.setSlackNotificationsMergedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_MERGED_ENABLED, slackNotificationsMergedEnabled.toString());
-
-        Boolean slackNotificationsCommentedEnabled = "on".equals(req.getParameter("slackNotificationsCommentedEnabled"));
-        slackGlobalSettingsService.setSlackNotificationsCommentedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_COMMENTED_ENABLED, slackNotificationsCommentedEnabled.toString());
+        slackGlobalSettingsService.setSlackNotificationsEnabled(bool(req, "slackNotificationsEnabled"));
+        slackGlobalSettingsService.setSlackNotificationsOpenedEnabled(bool(req, "slackNotificationsOpenedEnabled"));
+        slackGlobalSettingsService.setSlackNotificationsReopenedEnabled(bool(req, "slackNotificationsReopenedEnabled"));
+        slackGlobalSettingsService.setSlackNotificationsUpdatedEnabled(bool(req, "slackNotificationsUpdatedEnabled"));
+        slackGlobalSettingsService.setSlackNotificationsApprovedEnabled(bool(req, "slackNotificationsApprovedEnabled"));
+        slackGlobalSettingsService.setSlackNotificationsUnapprovedEnabled(bool(req, "slackNotificationsUnapprovedEnabled"));
+        slackGlobalSettingsService.setSlackNotificationsDeclinedEnabled(bool(req, "slackNotificationsDeclinedEnabled"));
+        slackGlobalSettingsService.setSlackNotificationsMergedEnabled(bool(req, "slackNotificationsMergedEnabled"));
+        slackGlobalSettingsService.setSlackNotificationsCommentedEnabled(bool(req, "slackNotificationsCommentedEnabled"));
 
         NotificationLevel notificationLevel = NotificationLevel.VERBOSE;
         if (null != req.getParameter("slackNotificationLevel")) {
             notificationLevel = NotificationLevel.valueOf(req.getParameter("slackNotificationLevel"));
         }
-        slackGlobalSettingsService.setNotificationLevel(KEY_GLOBAL_SETTING_NOTIFICATIONS_LEVEL, notificationLevel.toString());
+        slackGlobalSettingsService.setNotificationLevel(notificationLevel.toString());
 
         NotificationLevel notificationPrLevel = NotificationLevel.VERBOSE;
         if (null != req.getParameter("slackNotificationPrLevel")) {
             notificationPrLevel = NotificationLevel.valueOf(req.getParameter("slackNotificationPrLevel"));
         }
-        slackGlobalSettingsService.setNotificationPrLevel(KEY_GLOBAL_SETTING_NOTIFICATIONS_PR_LEVEL, notificationPrLevel.toString());
+        slackGlobalSettingsService.setNotificationPrLevel(notificationPrLevel.toString());
 
-        Boolean slackNotificationsEnabledForPush = "on".equals(req.getParameter("slackNotificationsEnabledForPush"));
-        slackGlobalSettingsService.setSlackNotificationsEnabledForPush(KEY_GLOBAL_SETTING_NOTIFICATIONS_PUSH_ENABLED, slackNotificationsEnabledForPush.toString());
-
-        Boolean slackNotificationsEnabledForPersonal = "on".equals(req.getParameter("slackNotificationsEnabledForPersonal"));
-        slackGlobalSettingsService.setSlackNotificationsEnabledForPersonal(KEY_GLOBAL_SETTING_NOTIFICATIONS_PERSONAL_ENABLED, slackNotificationsEnabledForPersonal.toString());
+        slackGlobalSettingsService.setSlackNotificationsEnabledForPush(bool(req, "slackNotificationsEnabledForPush"));
+        slackGlobalSettingsService.setSlackNotificationsEnabledForPersonal(bool(req, "slackNotificationsEnabledForPersonal"));
 
         doGet(req, res);
     }
@@ -131,21 +92,21 @@ public class SlackGlobalSettingsServlet extends HttpServlet {
 
         validationService.validateForGlobal(Permission.ADMIN);
 
-        String webHookUrl = slackGlobalSettingsService.getWebHookUrl(KEY_GLOBAL_SETTING_HOOK_URL);
-        String channelName = slackGlobalSettingsService.getChannelName(KEY_GLOBAL_SETTING_CHANNEL_NAME);
-        Boolean slackNotificationsEnabled = slackGlobalSettingsService.getSlackNotificationsEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_ENABLED);
-        Boolean slackNotificationsOpenedEnabled = slackGlobalSettingsService.getSlackNotificationsOpenedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_OPENED_ENABLED);
-        Boolean slackNotificationsReopenedEnabled = slackGlobalSettingsService.getSlackNotificationsReopenedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_REOPENED_ENABLED);
-        Boolean slackNotificationsUpdatedEnabled = slackGlobalSettingsService.getSlackNotificationsUpdatedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_UPDATED_ENABLED);
-        Boolean slackNotificationsApprovedEnabled = slackGlobalSettingsService.getSlackNotificationsApprovedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_APPROVED_ENABLED);
-        Boolean slackNotificationsUnapprovedEnabled = slackGlobalSettingsService.getSlackNotificationsUnapprovedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_UNAPPROVED_ENABLED);
-        Boolean slackNotificationsDeclinedEnabled = slackGlobalSettingsService.getSlackNotificationsDeclinedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_DECLINED_ENABLED);
-        Boolean slackNotificationsMergedEnabled = slackGlobalSettingsService.getSlackNotificationsMergedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_MERGED_ENABLED);
-        Boolean slackNotificationsCommentedEnabled = slackGlobalSettingsService.getSlackNotificationsCommentedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_COMMENTED_ENABLED);
-        Boolean slackNotificationsEnabledForPush = slackGlobalSettingsService.getSlackNotificationsEnabledForPush(KEY_GLOBAL_SETTING_NOTIFICATIONS_PUSH_ENABLED);
-        Boolean slackNotificationsEnabledForPersonal = slackGlobalSettingsService.getSlackNotificationsEnabledForPersonal(KEY_GLOBAL_SETTING_NOTIFICATIONS_PERSONAL_ENABLED);
-        String notificationLevel = slackGlobalSettingsService.getNotificationLevel(KEY_GLOBAL_SETTING_NOTIFICATIONS_LEVEL).toString();
-        String notificationPrLevel = slackGlobalSettingsService.getNotificationPrLevel(KEY_GLOBAL_SETTING_NOTIFICATIONS_PR_LEVEL).toString();
+        String webHookUrl = slackGlobalSettingsService.getWebHookUrl();
+        String channelName = slackGlobalSettingsService.getChannelName();
+        Boolean slackNotificationsEnabled = slackGlobalSettingsService.getSlackNotificationsEnabled();
+        Boolean slackNotificationsOpenedEnabled = slackGlobalSettingsService.getSlackNotificationsOpenedEnabled();
+        Boolean slackNotificationsReopenedEnabled = slackGlobalSettingsService.getSlackNotificationsReopenedEnabled();
+        Boolean slackNotificationsUpdatedEnabled = slackGlobalSettingsService.getSlackNotificationsUpdatedEnabled();
+        Boolean slackNotificationsApprovedEnabled = slackGlobalSettingsService.getSlackNotificationsApprovedEnabled();
+        Boolean slackNotificationsUnapprovedEnabled = slackGlobalSettingsService.getSlackNotificationsUnapprovedEnabled();
+        Boolean slackNotificationsDeclinedEnabled = slackGlobalSettingsService.getSlackNotificationsDeclinedEnabled();
+        Boolean slackNotificationsMergedEnabled = slackGlobalSettingsService.getSlackNotificationsMergedEnabled();
+        Boolean slackNotificationsCommentedEnabled = slackGlobalSettingsService.getSlackNotificationsCommentedEnabled();
+        Boolean slackNotificationsEnabledForPush = slackGlobalSettingsService.getSlackNotificationsEnabledForPush();
+        Boolean slackNotificationsEnabledForPersonal = slackGlobalSettingsService.getSlackNotificationsEnabledForPersonal();
+        String notificationLevel = slackGlobalSettingsService.getNotificationLevel().toString();
+        String notificationPrLevel = slackGlobalSettingsService.getNotificationPrLevel().toString();
 
         render(response,
                 "bitbucketserver.page.slack.global.settings.viewGlobalSlackSettings",
@@ -185,4 +146,7 @@ public class SlackGlobalSettingsServlet extends HttpServlet {
         }
     }
 
+    private boolean bool(HttpServletRequest req, String name) {
+        return "on".equals(req.getParameter(name));
+    }
 }

--- a/src/main/java/com/pragbits/bitbucketserver/SlackGlobalSettingsServlet.java
+++ b/src/main/java/com/pragbits/bitbucketserver/SlackGlobalSettingsServlet.java
@@ -54,7 +54,7 @@ public class SlackGlobalSettingsServlet extends HttpServlet {
     }
 
     @Override
-    protected  void doPost(HttpServletRequest req, HttpServletResponse res)
+    protected void doPost(HttpServletRequest req, HttpServletResponse res)
             throws ServletException, IOException {
 
         try {
@@ -69,62 +69,33 @@ public class SlackGlobalSettingsServlet extends HttpServlet {
         slackGlobalSettingsService.setWebHookUrl(KEY_GLOBAL_SETTING_HOOK_URL, globalWebHookUrl);
 
         String slackChannelName = req.getParameter("slackChannelName");
-        if (null != slackChannelName) {
-            slackGlobalSettingsService.setChannelName(KEY_GLOBAL_SETTING_CHANNEL_NAME, slackChannelName);
-        }
+        slackGlobalSettingsService.setChannelName(KEY_GLOBAL_SETTING_CHANNEL_NAME, slackChannelName);
 
-        Boolean slackNotificationsEnabled = false;
-        if (null != req.getParameter("slackNotificationsEnabled") && req.getParameter("slackNotificationsEnabled").equals("on")) {
-            slackNotificationsEnabled = true;
-        }
+        Boolean slackNotificationsEnabled = "on".equals(req.getParameter("slackNotificationsEnabled"));
         slackGlobalSettingsService.setSlackNotificationsEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_ENABLED, slackNotificationsEnabled.toString());
 
-        Boolean slackNotificationsOpenedEnabled = false;
-        if (null != req.getParameter("slackNotificationsOpenedEnabled") && req.getParameter("slackNotificationsOpenedEnabled").equals("on")) {
-            slackNotificationsOpenedEnabled = true;
-        }
+        Boolean slackNotificationsOpenedEnabled = "on".equals(req.getParameter("slackNotificationsOpenedEnabled"));
         slackGlobalSettingsService.setSlackNotificationsOpenedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_OPENED_ENABLED, slackNotificationsOpenedEnabled.toString());
 
-        Boolean slackNotificationsReopenedEnabled = false;
-        if (null != req.getParameter("slackNotificationsReopenedEnabled") && req.getParameter("slackNotificationsReopenedEnabled").equals("on")) {
-            slackNotificationsReopenedEnabled = true;
-        }
+        Boolean slackNotificationsReopenedEnabled = "on".equals(req.getParameter("slackNotificationsReopenedEnabled"));
         slackGlobalSettingsService.setSlackNotificationsReopenedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_REOPENED_ENABLED, slackNotificationsReopenedEnabled.toString());
 
-        Boolean slackNotificationsUpdatedEnabled = false;
-        if (null != req.getParameter("slackNotificationsUpdatedEnabled") && req.getParameter("slackNotificationsUpdatedEnabled").equals("on")) {
-            slackNotificationsUpdatedEnabled = true;
-        }
+        Boolean slackNotificationsUpdatedEnabled = "on".equals(req.getParameter("slackNotificationsUpdatedEnabled"));
         slackGlobalSettingsService.setSlackNotificationsUpdatedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_UPDATED_ENABLED, slackNotificationsUpdatedEnabled.toString());
 
-        Boolean slackNotificationsApprovedEnabled = false;
-        if (null != req.getParameter("slackNotificationsApprovedEnabled") && req.getParameter("slackNotificationsApprovedEnabled").equals("on")) {
-            slackNotificationsApprovedEnabled = true;
-        }
+        Boolean slackNotificationsApprovedEnabled = "on".equals(req.getParameter("slackNotificationsApprovedEnabled"));
         slackGlobalSettingsService.setSlackNotificationsApprovedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_APPROVED_ENABLED, slackNotificationsApprovedEnabled.toString());
 
-        Boolean slackNotificationsUnapprovedEnabled = false;
-        if (null != req.getParameter("slackNotificationsUnapprovedEnabled") && req.getParameter("slackNotificationsUnapprovedEnabled").equals("on")) {
-            slackNotificationsUnapprovedEnabled = true;
-        }
+        Boolean slackNotificationsUnapprovedEnabled = "on".equals(req.getParameter("slackNotificationsUnapprovedEnabled"));
         slackGlobalSettingsService.setSlackNotificationsUnapprovedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_UNAPPROVED_ENABLED, slackNotificationsUnapprovedEnabled.toString());
 
-        Boolean slackNotificationsDeclinedEnabled = false;
-        if (null != req.getParameter("slackNotificationsDeclinedEnabled") && req.getParameter("slackNotificationsDeclinedEnabled").equals("on")) {
-            slackNotificationsDeclinedEnabled = true;
-        }
+        Boolean slackNotificationsDeclinedEnabled = "on".equals(req.getParameter("slackNotificationsDeclinedEnabled"));
         slackGlobalSettingsService.setSlackNotificationsDeclinedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_DECLINED_ENABLED, slackNotificationsDeclinedEnabled.toString());
 
-        Boolean slackNotificationsMergedEnabled = false;
-        if (null != req.getParameter("slackNotificationsMergedEnabled") && req.getParameter("slackNotificationsMergedEnabled").equals("on")) {
-            slackNotificationsMergedEnabled = true;
-        }
+        Boolean slackNotificationsMergedEnabled = "on".equals(req.getParameter("slackNotificationsMergedEnabled"));
         slackGlobalSettingsService.setSlackNotificationsMergedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_MERGED_ENABLED, slackNotificationsMergedEnabled.toString());
 
-        Boolean slackNotificationsCommentedEnabled = false;
-        if (null != req.getParameter("slackNotificationsCommentedEnabled") && req.getParameter("slackNotificationsCommentedEnabled").equals("on")) {
-            slackNotificationsCommentedEnabled = true;
-        }
+        Boolean slackNotificationsCommentedEnabled = "on".equals(req.getParameter("slackNotificationsCommentedEnabled"));
         slackGlobalSettingsService.setSlackNotificationsCommentedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_COMMENTED_ENABLED, slackNotificationsCommentedEnabled.toString());
 
         NotificationLevel notificationLevel = NotificationLevel.VERBOSE;
@@ -139,18 +110,11 @@ public class SlackGlobalSettingsServlet extends HttpServlet {
         }
         slackGlobalSettingsService.setNotificationPrLevel(KEY_GLOBAL_SETTING_NOTIFICATIONS_PR_LEVEL, notificationPrLevel.toString());
 
-        Boolean slackNotificationsEnabledForPush = false;
-        if (null != req.getParameter("slackNotificationsEnabledForPush") && req.getParameter("slackNotificationsEnabledForPush").equals("on")) {
-            slackNotificationsEnabledForPush = true;
-        }
+        Boolean slackNotificationsEnabledForPush = "on".equals(req.getParameter("slackNotificationsEnabledForPush"));
         slackGlobalSettingsService.setSlackNotificationsEnabledForPush(KEY_GLOBAL_SETTING_NOTIFICATIONS_PUSH_ENABLED, slackNotificationsEnabledForPush.toString());
 
-        Boolean slackNotificationsEnabledForPersonal = false;
-        if (null != req.getParameter("slackNotificationsEnabledForPersonal") && req.getParameter("slackNotificationsEnabledForPersonal").equals("on")) {
-            slackNotificationsEnabledForPersonal = true;
-        }
+        Boolean slackNotificationsEnabledForPersonal = "on".equals(req.getParameter("slackNotificationsEnabledForPersonal"));
         slackGlobalSettingsService.setSlackNotificationsEnabledForPersonal(KEY_GLOBAL_SETTING_NOTIFICATIONS_PERSONAL_ENABLED, slackNotificationsEnabledForPersonal.toString());
-
 
         doGet(req, res);
     }
@@ -168,15 +132,7 @@ public class SlackGlobalSettingsServlet extends HttpServlet {
         validationService.validateForGlobal(Permission.ADMIN);
 
         String webHookUrl = slackGlobalSettingsService.getWebHookUrl(KEY_GLOBAL_SETTING_HOOK_URL);
-        if (null == webHookUrl || webHookUrl.equals("")) {
-            webHookUrl = "";
-        }
-
         String channelName = slackGlobalSettingsService.getChannelName(KEY_GLOBAL_SETTING_CHANNEL_NAME);
-        if (null == channelName || channelName.equals("")) {
-            channelName = "";
-        }
-
         Boolean slackNotificationsEnabled = slackGlobalSettingsService.getSlackNotificationsEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_ENABLED);
         Boolean slackNotificationsOpenedEnabled = slackGlobalSettingsService.getSlackNotificationsOpenedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_OPENED_ENABLED);
         Boolean slackNotificationsReopenedEnabled = slackGlobalSettingsService.getSlackNotificationsReopenedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_REOPENED_ENABLED);

--- a/src/main/java/com/pragbits/bitbucketserver/SlackGlobalSettingsServlet.java
+++ b/src/main/java/com/pragbits/bitbucketserver/SlackGlobalSettingsServlet.java
@@ -65,10 +65,8 @@ public class SlackGlobalSettingsServlet extends HttpServlet {
             return;
         }
 
-        String globalWebHookUrl = req.getParameter("slackGlobalWebHookUrl");
-        if (null != globalWebHookUrl) {
-            slackGlobalSettingsService.setWebHookUrl(KEY_GLOBAL_SETTING_HOOK_URL, globalWebHookUrl);
-        }
+        final String globalWebHookUrl = req.getParameter("slackGlobalWebHookUrl").trim();
+        slackGlobalSettingsService.setWebHookUrl(KEY_GLOBAL_SETTING_HOOK_URL, globalWebHookUrl);
 
         String slackChannelName = req.getParameter("slackChannelName");
         if (null != slackChannelName) {

--- a/src/main/java/com/pragbits/bitbucketserver/SlackSettingsServlet.java
+++ b/src/main/java/com/pragbits/bitbucketserver/SlackSettingsServlet.java
@@ -127,7 +127,7 @@ public class SlackSettingsServlet extends HttpServlet {
         }
 
         String channel = req.getParameter("slackChannelName");
-        String webHookUrl = req.getParameter("slackWebHookUrl");
+        String webHookUrl = req.getParameter("slackWebHookUrl").trim();
         slackSettingsService.setSlackSettings(
                 repository,
                 new ImmutableSlackSettings(

--- a/src/main/java/com/pragbits/bitbucketserver/SlackSettingsServlet.java
+++ b/src/main/java/com/pragbits/bitbucketserver/SlackSettingsServlet.java
@@ -45,7 +45,7 @@ public class SlackSettingsServlet extends HttpServlet {
     }
 
     @Override
-    protected  void doPost(HttpServletRequest req, HttpServletResponse res)
+    protected void doPost(HttpServletRequest req, HttpServletResponse res)
         throws ServletException, IOException {
 
         try {
@@ -54,66 +54,6 @@ public class SlackSettingsServlet extends HttpServlet {
             // Skip form processing
             doGet(req, res);
             return;
-        }
-
-        boolean overrideEnabled = false;
-        if (null != req.getParameter("slackNotificationsOverrideEnabled") && req.getParameter("slackNotificationsOverrideEnabled").equals("on")) {
-            overrideEnabled = true;
-        }
-
-        boolean enabled = false;
-        if (null != req.getParameter("slackNotificationsEnabled") && req.getParameter("slackNotificationsEnabled").equals("on")) {
-          enabled = true;
-        }
-
-        boolean openedEnabled = false;
-        if (null != req.getParameter("slackNotificationsOpenedEnabled") && req.getParameter("slackNotificationsOpenedEnabled").equals("on")) {
-            openedEnabled = true;
-        }
-
-        boolean reopenedEnabled = false;
-        if (null != req.getParameter("slackNotificationsReopenedEnabled") && req.getParameter("slackNotificationsReopenedEnabled").equals("on")) {
-            reopenedEnabled = true;
-        }
-
-        boolean updatedEnabled = false;
-        if (null != req.getParameter("slackNotificationsUpdatedEnabled") && req.getParameter("slackNotificationsUpdatedEnabled").equals("on")) {
-            updatedEnabled = true;
-        }
-
-        boolean approvedEnabled = false;
-        if (null != req.getParameter("slackNotificationsApprovedEnabled") && req.getParameter("slackNotificationsApprovedEnabled").equals("on")) {
-            approvedEnabled = true;
-        }
-
-        boolean unapprovedEnabled = false;
-        if (null != req.getParameter("slackNotificationsUnapprovedEnabled") && req.getParameter("slackNotificationsUnapprovedEnabled").equals("on")) {
-            unapprovedEnabled = true;
-        }
-
-        boolean declinedEnabled = false;
-        if (null != req.getParameter("slackNotificationsDeclinedEnabled") && req.getParameter("slackNotificationsDeclinedEnabled").equals("on")) {
-            declinedEnabled = true;
-        }
-
-        boolean mergedEnabled = false;
-        if (null != req.getParameter("slackNotificationsMergedEnabled") && req.getParameter("slackNotificationsMergedEnabled").equals("on")) {
-            mergedEnabled = true;
-        }
-
-        boolean commentedEnabled = false;
-        if (null != req.getParameter("slackNotificationsCommentedEnabled") && req.getParameter("slackNotificationsCommentedEnabled").equals("on")) {
-            commentedEnabled = true;
-        }
-
-        boolean enabledPush = false;
-        if (null != req.getParameter("slackNotificationsEnabledForPush") && req.getParameter("slackNotificationsEnabledForPush").equals("on")) {
-            enabledPush = true;
-        }
-
-        boolean enabledPersonal = false;
-        if (null != req.getParameter("slackNotificationsEnabledForPersonal") && req.getParameter("slackNotificationsEnabledForPersonal").equals("on")) {
-            enabledPersonal = true;
         }
 
         NotificationLevel notificationLevel = NotificationLevel.VERBOSE;
@@ -126,27 +66,25 @@ public class SlackSettingsServlet extends HttpServlet {
             notificationPrLevel = NotificationLevel.valueOf(req.getParameter("slackNotificationPrLevel"));
         }
 
-        String channel = req.getParameter("slackChannelName");
-        String webHookUrl = req.getParameter("slackWebHookUrl").trim();
         slackSettingsService.setSlackSettings(
                 repository,
                 new ImmutableSlackSettings(
-                        overrideEnabled,
-                        enabled,
-                        openedEnabled,
-                        reopenedEnabled,
-                        updatedEnabled,
-                        approvedEnabled,
-                        unapprovedEnabled,
-                        declinedEnabled,
-                        mergedEnabled,
-                        commentedEnabled,
-                        enabledPush,
-                        enabledPersonal,
+                        "on".equals(req.getParameter("slackNotificationsOverrideEnabled")),
+                        "on".equals(req.getParameter("slackNotificationsEnabled")),
+                        "on".equals(req.getParameter("slackNotificationsOpenedEnabled")),
+                        "on".equals(req.getParameter("slackNotificationsReopenedEnabled")),
+                        "on".equals(req.getParameter("slackNotificationsUpdatedEnabled")),
+                        "on".equals(req.getParameter("slackNotificationsApprovedEnabled")),
+                        "on".equals(req.getParameter("slackNotificationsUnapprovedEnabled")),
+                        "on".equals(req.getParameter("slackNotificationsDeclinedEnabled")),
+                        "on".equals(req.getParameter("slackNotificationsMergedEnabled")),
+                        "on".equals(req.getParameter("slackNotificationsCommentedEnabled")),
+                        "on".equals(req.getParameter("slackNotificationsEnabledForPush")),
+                        "on".equals(req.getParameter("slackNotificationsEnabledForPersonal")),
                         notificationLevel,
                         notificationPrLevel,
-                        channel,
-                        webHookUrl));
+                        req.getParameter("slackChannelName"),
+                        req.getParameter("slackWebHookUrl").trim()));
 
         doGet(req, res);
     }

--- a/src/main/java/com/pragbits/bitbucketserver/components/PullRequestActivityListener.java
+++ b/src/main/java/com/pragbits/bitbucketserver/components/PullRequestActivityListener.java
@@ -21,8 +21,6 @@ import java.util.List;
 import java.util.Set;
 
 public class PullRequestActivityListener {
-    static final String KEY_GLOBAL_SETTING_HOOK_URL = "stash2slack.globalsettings.hookurl";
-    static final String KEY_GLOBAL_SLACK_CHANNEL_NAME = "stash2slack.globalsettings.channelname";
     private static final Logger log = LoggerFactory.getLogger(PullRequestActivityListener.class);
 
     private final SlackGlobalSettingsService slackGlobalSettingsService;
@@ -50,7 +48,7 @@ public class PullRequestActivityListener {
         // find out if notification is enabled for this repo
         Repository repository = event.getPullRequest().getToRef().getRepository();
         SlackSettings slackSettings = slackSettingsService.getSlackSettings(repository);
-        String globalHookUrl = slackGlobalSettingsService.getWebHookUrl(KEY_GLOBAL_SETTING_HOOK_URL);
+        String globalHookUrl = slackGlobalSettingsService.getWebHookUrl();
 
 
         SettingsSelector settingsSelector = new SettingsSelector(slackSettingsService,  slackGlobalSettingsService, repository);
@@ -60,7 +58,7 @@ public class PullRequestActivityListener {
 
             String localHookUrl = resolvedSlackSettings.getSlackWebHookUrl();
             WebHookSelector hookSelector = new WebHookSelector(globalHookUrl, localHookUrl);
-            ChannelSelector channelSelector = new ChannelSelector(slackGlobalSettingsService.getChannelName(KEY_GLOBAL_SLACK_CHANNEL_NAME), slackSettings.getSlackChannelName());
+            ChannelSelector channelSelector = new ChannelSelector(slackGlobalSettingsService.getChannelName(), slackSettings.getSlackChannelName());
 
             if (!hookSelector.isHookValid()) {
                 log.error("There is no valid configured Web hook url! Reason: " + hookSelector.getProblem());

--- a/src/main/java/com/pragbits/bitbucketserver/components/RepositoryPushActivityListener.java
+++ b/src/main/java/com/pragbits/bitbucketserver/components/RepositoryPushActivityListener.java
@@ -25,8 +25,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class RepositoryPushActivityListener {
-    static final String KEY_GLOBAL_SETTING_HOOK_URL = "stash2slack.globalsettings.hookurl";
-    static final String KEY_GLOBAL_SLACK_CHANNEL_NAME = "stash2slack.globalsettings.channelname";
     private static final Logger log = LoggerFactory.getLogger(RepositoryPushActivityListener.class);
 
     private final SlackGlobalSettingsService slackGlobalSettingsService;
@@ -53,7 +51,7 @@ public class RepositoryPushActivityListener {
         // find out if notification is enabled for this repo
         Repository repository = event.getRepository();
         SlackSettings slackSettings = slackSettingsService.getSlackSettings(repository);
-        String globalHookUrl = slackGlobalSettingsService.getWebHookUrl(KEY_GLOBAL_SETTING_HOOK_URL);
+        String globalHookUrl = slackGlobalSettingsService.getWebHookUrl();
 
         SettingsSelector settingsSelector = new SettingsSelector(slackSettingsService,  slackGlobalSettingsService, repository);
         SlackSettings resolvedSlackSettings = settingsSelector.getResolvedSlackSettings();
@@ -61,7 +59,7 @@ public class RepositoryPushActivityListener {
         if (resolvedSlackSettings.isSlackNotificationsEnabledForPush()) {
             String localHookUrl = slackSettings.getSlackWebHookUrl();
             WebHookSelector hookSelector = new WebHookSelector(globalHookUrl, localHookUrl);
-            ChannelSelector channelSelector = new ChannelSelector(slackGlobalSettingsService.getChannelName(KEY_GLOBAL_SLACK_CHANNEL_NAME), slackSettings.getSlackChannelName());
+            ChannelSelector channelSelector = new ChannelSelector(slackGlobalSettingsService.getChannelName(), slackSettings.getSlackChannelName());
 
             if (!hookSelector.isHookValid()) {
                 log.error("There is no valid configured Web hook url! Reason: " + hookSelector.getProblem());

--- a/src/main/java/com/pragbits/bitbucketserver/tools/SettingsSelector.java
+++ b/src/main/java/com/pragbits/bitbucketserver/tools/SettingsSelector.java
@@ -8,34 +8,12 @@ import com.pragbits.bitbucketserver.SlackSettingsService;
 
 public class SettingsSelector {
 
-    private SlackSettingsService slackSettingsService;
     private SlackGlobalSettingsService slackGlobalSettingsService;
     private SlackSettings slackSettings;
-    private Repository repository;
     private SlackSettings resolvedSlackSettings;
 
-
-    private static final String KEY_GLOBAL_SETTING_HOOK_URL = "stash2slack.globalsettings.hookurl";
-    private static final String KEY_GLOBAL_SETTING_CHANNEL_NAME = "stash2slack.globalsettings.channelname";
-    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_ENABLED = "stash2slack.globalsettings.slacknotificationsenabled";
-    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_OPENED_ENABLED = "stash2slack.globalsettings.slacknotificationsopenedenabled";
-    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_REOPENED_ENABLED = "stash2slack.globalsettings.slacknotificationsreopenedenabled";
-    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_UPDATED_ENABLED = "stash2slack.globalsettings.slacknotificationsupdatedenabled";
-    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_APPROVED_ENABLED = "stash2slack.globalsettings.slacknotificationsapprovedenabled";
-    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_UNAPPROVED_ENABLED = "stash2slack.globalsettings.slacknotificationsunapprovedenabled";
-    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_DECLINED_ENABLED = "stash2slack.globalsettings.slacknotificationsdeclinedenabled";
-    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_MERGED_ENABLED = "stash2slack.globalsettings.slacknotificationsmergedenabled";
-    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_COMMENTED_ENABLED = "stash2slack.globalsettings.slacknotificationscommentedenabled";
-    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_LEVEL = "stash2slack.globalsettings.slacknotificationslevel";
-    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_PR_LEVEL = "stash2slack.globalsettings.slacknotificationsprlevel";
-    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_PUSH_ENABLED = "stash2slack.globalsettings.slacknotificationspushenabled";
-    private static final String KEY_GLOBAL_SETTING_NOTIFICATIONS_PERSONAL_ENABLED = "stash2slack.globalsettings.slacknotificationspersonalenabled";
-
-
     public SettingsSelector(SlackSettingsService slackSettingsService, SlackGlobalSettingsService slackGlobalSettingsService, Repository repository) {
-        this.slackSettingsService = slackSettingsService;
         this.slackGlobalSettingsService = slackGlobalSettingsService;
-        this.repository = repository;
         this.slackSettings = slackSettingsService.getSlackSettings(repository);
         this.setResolvedSlackSettings();
     }
@@ -46,22 +24,22 @@ public class SettingsSelector {
 
     private void setResolvedSlackSettings() {
         resolvedSlackSettings = new ImmutableSlackSettings(
-                slackSettings.isSlackNotificationsOverrideEnabled() ? true : false,
-                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsEnabled() : slackGlobalSettingsService.getSlackNotificationsEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_ENABLED),
-                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsOpenedEnabled() : slackGlobalSettingsService.getSlackNotificationsOpenedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_OPENED_ENABLED),
-                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsReopenedEnabled() : slackGlobalSettingsService.getSlackNotificationsReopenedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_REOPENED_ENABLED),
-                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsUpdatedEnabled() : slackGlobalSettingsService.getSlackNotificationsUpdatedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_UPDATED_ENABLED),
-                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsApprovedEnabled() : slackGlobalSettingsService.getSlackNotificationsApprovedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_APPROVED_ENABLED),
-                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsUnapprovedEnabled() : slackGlobalSettingsService.getSlackNotificationsUnapprovedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_UNAPPROVED_ENABLED),
-                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsDeclinedEnabled() : slackGlobalSettingsService.getSlackNotificationsDeclinedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_DECLINED_ENABLED),
-                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsMergedEnabled() : slackGlobalSettingsService.getSlackNotificationsMergedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_MERGED_ENABLED),
-                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsCommentedEnabled() : slackGlobalSettingsService.getSlackNotificationsCommentedEnabled(KEY_GLOBAL_SETTING_NOTIFICATIONS_COMMENTED_ENABLED),
-                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsEnabledForPush() : slackGlobalSettingsService.getSlackNotificationsEnabledForPush(KEY_GLOBAL_SETTING_NOTIFICATIONS_PUSH_ENABLED),
-                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsEnabledForPersonal() : slackGlobalSettingsService.getSlackNotificationsEnabledForPersonal(KEY_GLOBAL_SETTING_NOTIFICATIONS_PERSONAL_ENABLED),
-                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.getNotificationLevel() : slackGlobalSettingsService.getNotificationLevel(KEY_GLOBAL_SETTING_NOTIFICATIONS_LEVEL),
-                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.getNotificationPrLevel() : slackGlobalSettingsService.getNotificationPrLevel(KEY_GLOBAL_SETTING_NOTIFICATIONS_PR_LEVEL),
-                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.getSlackChannelName() : slackGlobalSettingsService.getChannelName(KEY_GLOBAL_SETTING_CHANNEL_NAME),
-                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.getSlackWebHookUrl() : slackGlobalSettingsService.getWebHookUrl(KEY_GLOBAL_SETTING_HOOK_URL)
+                slackSettings.isSlackNotificationsOverrideEnabled(),
+                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsEnabled() : slackGlobalSettingsService.getSlackNotificationsEnabled(),
+                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsOpenedEnabled() : slackGlobalSettingsService.getSlackNotificationsOpenedEnabled(),
+                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsReopenedEnabled() : slackGlobalSettingsService.getSlackNotificationsReopenedEnabled(),
+                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsUpdatedEnabled() : slackGlobalSettingsService.getSlackNotificationsUpdatedEnabled(),
+                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsApprovedEnabled() : slackGlobalSettingsService.getSlackNotificationsApprovedEnabled(),
+                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsUnapprovedEnabled() : slackGlobalSettingsService.getSlackNotificationsUnapprovedEnabled(),
+                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsDeclinedEnabled() : slackGlobalSettingsService.getSlackNotificationsDeclinedEnabled(),
+                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsMergedEnabled() : slackGlobalSettingsService.getSlackNotificationsMergedEnabled(),
+                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsCommentedEnabled() : slackGlobalSettingsService.getSlackNotificationsCommentedEnabled(),
+                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsEnabledForPush() : slackGlobalSettingsService.getSlackNotificationsEnabledForPush(),
+                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.isSlackNotificationsEnabledForPersonal() : slackGlobalSettingsService.getSlackNotificationsEnabledForPersonal(),
+                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.getNotificationLevel() : slackGlobalSettingsService.getNotificationLevel(),
+                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.getNotificationPrLevel() : slackGlobalSettingsService.getNotificationPrLevel(),
+                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.getSlackChannelName() : slackGlobalSettingsService.getChannelName(),
+                slackSettings.isSlackNotificationsOverrideEnabled() ? slackSettings.getSlackWebHookUrl() : slackGlobalSettingsService.getWebHookUrl()
         );
     }
 


### PR DESCRIPTION
I only wanted to trim the hook url, because I ran into the problem that I had a space at the beginning of the url, and it didn't work.

But then I also refactored the whole settings and simplified them heavily. I moved the keys to the service and removed the key parameter, because it was already in the method name. I also removed some duplicate code.