### PR TITLE
use darker colors for merged/declined

### DIFF
--- a/src/main/java/com/pragbits/bitbucketserver/ColorCode.java
+++ b/src/main/java/com/pragbits/bitbucketserver/ColorCode.java
@@ -5,9 +5,11 @@ public enum ColorCode {
     BLUE("#2267c4"),
     PALE_BLUE("#439fe0"),
     GREEN("#2dc422"),
+    DARK_GREEN("#1e8217"),
     PURPLE("#9055fc"),
     GRAY("#aabbcc"),
-    RED("#ff0024");
+    RED("#ff0024"),
+    DARK_RED("#990016");
 
     private String code;
 

--- a/src/main/java/com/pragbits/bitbucketserver/components/PullRequestActivityListener.java
+++ b/src/main/java/com/pragbits/bitbucketserver/components/PullRequestActivityListener.java
@@ -220,7 +220,7 @@ public class PullRequestActivityListener {
                     break;
 
                 case DECLINED:
-                    attachment.setColor(ColorCode.RED.getCode());
+                    attachment.setColor(ColorCode.DARK_RED.getCode());
                     attachment.setFallback(String.format("%s declined pull request \"%s\". <%s|(open)>",
                                                             userName,
                                                             event.getPullRequest().getTitle(),
@@ -232,7 +232,7 @@ public class PullRequestActivityListener {
                     break;
 
                 case MERGED:
-                    attachment.setColor(ColorCode.GREEN.getCode());
+                    attachment.setColor(ColorCode.DARK_GREEN.getCode());
                     attachment.setFallback(String.format("%s merged pull request \"%s\". <%s|(open)>",
                                                             userName,
                                                             event.getPullRequest().getTitle(),


### PR DESCRIPTION
I've added darker colors for the "close"-events (merged and declined) to differ them from approved/unapproved.